### PR TITLE
skia: add Android-specific file to build

### DIFF
--- a/skia.lua
+++ b/skia.lua
@@ -353,6 +353,7 @@ project "skia"
   local common_android = {
     common_unix,
     "src/core/SkTSearch.cpp",
+    "src/ports/SkDebug_android.cpp",
     "src/ports/SkFontHost_FreeType.cpp",
     "src/ports/SkFontHost_FreeType_common.cpp",
     "src/ports/SkFontMgr_android.cpp",


### PR DESCRIPTION
Include `SkDebug_android.cpp` in Android builds to prevent "undefined symbol" errors when linking with `runtimecore`. With this change in place, the `skia` library compiles for Android and links with `runtimecore` without error.

vTest (using a custom 3rd party archive built from this branch):
- [armv7](http://runtime-test.esri.com:8080/view/vTest/job/vtest-runtimecore-interface/3220/downstreambuildview/)
- [arm64](http://runtime-test.esri.com:8080/view/vTest/job/vtest-runtimecore-interface/3264/downstreambuildview/)
- [x86](http://runtime-test.esri.com:8080/view/vTest/job/vtest-runtimecore-interface/3282/downstreambuildview/)

Please review @itrombley @john4744 