### PR TITLE
fix GCC arm64 builds

### DIFF
--- a/src/opts/SkRasterPipeline_opts.h
+++ b/src/opts/SkRasterPipeline_opts.h
@@ -729,7 +729,8 @@ SI F approx_powf(F x, F y) {
 }
 
 SI F from_half(U16 h) {
-#if defined(SK_CPU_ARM64) && !defined(SK_BUILD_FOR_GOOGLE3)  // Temporary workaround for some Google3 builds.
+#if defined(JUMPER_IS_NEON) && defined(SK_CPU_ARM64) \
+    && !defined(SK_BUILD_FOR_GOOGLE3)  // Temporary workaround for some Google3 builds.
     return vcvt_f32_f16(h);
 
 #elif defined(JUMPER_IS_HSW) || defined(JUMPER_IS_AVX512)
@@ -749,7 +750,8 @@ SI F from_half(U16 h) {
 }
 
 SI U16 to_half(F f) {
-#if defined(SK_CPU_ARM64) && !defined(SK_BUILD_FOR_GOOGLE3)  // Temporary workaround for some Google3 builds.
+#if defined(JUMPER_IS_NEON) && defined(SK_CPU_ARM64) \
+    && !defined(SK_BUILD_FOR_GOOGLE3)  // Temporary workaround for some Google3 builds.
     return vcvt_f16_f32(f);
 
 #elif defined(JUMPER_IS_HSW) || defined(JUMPER_IS_AVX512)


### PR DESCRIPTION
@chri7325. Please review. This is a cherry pick that I need to build for arm64 Embedded Linux targets with gcc.

------

These two guards are checking if we're building for aarch64 and thus
have F16 conversion instructions, but weren't checking if we want to use
them (if we have them _and_ we're being compiled by Clang).  At head
we're trying to pass a 2-byte uint16_t to a function expecting an 8-byte
uint16x4_t, etc.

Change-Id: I21f6cd2100ec81ccdd47c4ec0575107624cd7c5a
Reviewed-on: https://skia-review.googlesource.com/c/skia/+/225257
Reviewed-by: Herb Derby <herb@google.com>
Commit-Queue: Mike Klein <mtklein@google.com>
(cherry picked from commit 7aacb0b30a86936aedd1308708d1a51d951197f2)