### PR TITLE
Migrate all skia defines to a user config file

### DIFF
--- a/include/config/SkUserConfig.h
+++ b/include/config/SkUserConfig.h
@@ -100,11 +100,10 @@
  */
 //#define SK_MAX_SIZE_FOR_LCDTEXT     48
 
-// [ivan4258] For RTC, we always use BGRA.
-#define SK_B32_SHIFT 0
-#define SK_G32_SHIFT 8
-#define SK_R32_SHIFT 16
-#define SK_A32_SHIFT 24
+/*  Change the kN32_SkColorType ordering to BGRA to work in X windows.
+ */
+//#define SK_R32_SHIFT    16
+
 
 /* Determines whether to build code that supports the GPU backend. Some classes
    that are not GPU-specific, such as SkShader subclasses, have optional code
@@ -122,5 +121,18 @@
  */
 //#define SK_HISTOGRAM_BOOLEAN(name, value)
 //#define SK_HISTOGRAM_ENUMERATION(name, value, boundary_value)
+
+// RTC defines ---------------------------------------------------------------------------------
+#define SK_HAS_JPEG_LIBRARY
+#define SK_HAS_PNG_LIBRARY
+#define SK_SUPPORT_GPU 0
+
+// always use BGRA.
+#define SK_B32_SHIFT 0
+#define SK_G32_SHIFT 8
+#define SK_R32_SHIFT 16
+#define SK_A32_SHIFT 24
+
+// SK_CPU_SSE_LEVEL and SK_ARM_HAS_NEON are found through compiler defines in SkPreConfig.h
 
 #endif

--- a/skia.lua
+++ b/skia.lua
@@ -390,14 +390,7 @@ project "skia"
     "NoPCH",
   }
 
-  defines {
-    "SK_SUPPORT_GPU=0",
-    "SK_HAS_JPEG_LIBRARY",
-    "SK_HAS_PNG_LIBRARY",
-  }
-
   local t_includedirs = {
-    -- "../giflib/lib",
     "../libjpeg-turbo",
     "../libpng",
     "../zlib",
@@ -451,7 +444,6 @@ project "skia"
     configuration { "windows" }
 
       defines {
-        "SK_CPU_SSE_LEVEL=31",
         "_CRT_SECURE_NO_WARNINGS",
       }
 
@@ -529,10 +521,6 @@ project "skia"
 
     configuration { "linux" }
 
-      defines {
-        "SK_CPU_SSE_LEVEL=31",
-      }
-
       includedirs {
         "/usr/include/freetype2",
       }
@@ -581,10 +569,6 @@ project "skia"
     -- project specific configuration settings
 
     configuration { "macosx" }
-
-      defines {
-        "SK_CPU_SSE_LEVEL=31",
-      }
 
       files {
         common_cocoa,
@@ -654,10 +638,6 @@ project "skia"
     -- project specific configuration settings
 
     configuration { "ios_arm64_debug" }
-
-      defines {
-        "SK_ARM_HAS_NEON",
-      }
       
       files { opts_arm64 }
 
@@ -673,10 +653,6 @@ project "skia"
 
     configuration { "ios_arm64_release" }
 
-      defines {
-        "SK_ARM_HAS_NEON",
-      }
-
       files { opts_arm64 }
       
     -- -------------------------------------------------------------
@@ -691,10 +667,6 @@ project "skia"
 
     configuration { "ios_sim64_debug" }
 
-      defines {
-        "SK_CPU_SSE_LEVEL=31",
-      }
-
       files { opts_sse }
 
     -- -------------------------------------------------------------
@@ -708,10 +680,6 @@ project "skia"
     -- project specific configuration settings
 
     configuration { "ios_sim64_release" }
-
-      defines {
-        "SK_CPU_SSE_LEVEL=31",
-      }
 
       files { opts_sse }
 
@@ -750,11 +718,7 @@ project "skia"
 
     -- project specific configuration settings
 
-    configuration { "android_armv7_debug" }
-
-      defines {
-        "SK_ARM_HAS_NEON",
-      }
+    -- configuration { "android_armv7_debug" }
 
     -- -------------------------------------------------------------
     -- configuration { "android_armv7_release" }
@@ -766,11 +730,7 @@ project "skia"
 
     -- project specific configuration settings
 
-    configuration { "android_armv7_release" }
-
-      defines {
-        "SK_ARM_HAS_NEON",
-      }
+    -- configuration { "android_armv7_release" }
 
     -- -------------------------------------------------------------
     -- configuration { "android_x86_debug" }
@@ -783,10 +743,6 @@ project "skia"
     -- project specific configuration settings
 
     configuration { "android_x86_debug" }
-
-      defines {
-        "SK_CPU_SSE_LEVEL=31",
-      }
 
       files { opts_sse }
 
@@ -802,10 +758,6 @@ project "skia"
 
     configuration { "android_x86_release" }
 
-      defines {
-        "SK_CPU_SSE_LEVEL=31",
-      }
-
       files { opts_sse }
 
     -- -------------------------------------------------------------
@@ -820,10 +772,6 @@ project "skia"
 
     configuration { "android_arm64_debug" }
 
-      defines {
-        "SK_ARM_HAS_NEON",
-      }
-
       files { opts_arm64 }
       
     -- -------------------------------------------------------------
@@ -837,10 +785,6 @@ project "skia"
     -- project specific configuration settings
 
     configuration { "android_arm64_release" }
-
-      defines {
-        "SK_ARM_HAS_NEON",
-      }
 
       files { opts_arm64 }
       
@@ -884,11 +828,7 @@ project "skia"
 
     -- project specific configuration settings
 
-    configuration { "winuwp_debug", "x32" }
-
-      defines {
-        "SK_CPU_SSE_LEVEL=31",
-      }
+    -- configuration { "winuwp_debug", "x32" }
 
     -- -------------------------------------------------------------
     -- configuration { "winuwp_release", "x32" }
@@ -900,11 +840,7 @@ project "skia"
 
     -- project specific configuration settings
 
-    configuration { "winuwp_release", "x32" }
-
-      defines {
-        "SK_CPU_SSE_LEVEL=31",
-      }
+    -- configuration { "winuwp_release", "x32" }
 
     -- -------------------------------------------------------------
     -- configuration { "winuwp_debug", "x64" }
@@ -916,11 +852,7 @@ project "skia"
 
     -- project specific configuration settings
 
-    configuration { "winuwp_debug", "x64" }
-
-      defines {
-        "SK_CPU_SSE_LEVEL=31",
-      }
+    -- configuration { "winuwp_debug", "x64" }
 
     -- -------------------------------------------------------------
     -- configuration { "winuwp_release", "x64" }
@@ -932,11 +864,7 @@ project "skia"
 
     -- project specific configuration settings
 
-    configuration { "winuwp_release", "x64" }
-
-      defines {
-        "SK_CPU_SSE_LEVEL=31",
-      }
+    -- configuration { "winuwp_release", "x64" }
 
     -- -------------------------------------------------------------
     -- configuration { "winuwp_debug", "ARM" }


### PR DESCRIPTION
Skia defines were being handled through global lua defines. These got
out of sync with the recent skia update. To easily syncronize them, move
all defines to a user config file that allows skia to sanity check them
as well.

Related PR: https://devtopia.esri.com/3rdparty/architecture/pull/216
vTest: http://runtime-test.esri.com:8080/view/vTest/job/vtest-3rdparty_libraries-interface/404/downstreambuildview/