### PR TITLE
Add effects include folder

### DIFF
--- a/conanfile_rtc.py
+++ b/conanfile_rtc.py
@@ -19,6 +19,7 @@ class SkiaConan(ConanFile):
         self.copy("*.h*", src=base + "include/codec", dst=relative + "include/codec")
         self.copy("*.h*", src=base + "include/config", dst=relative + "include/config")
         self.copy("*.h*", src=base + "include/core", dst=relative + "include/core")
+        self.copy("*.h*", src=base + "include/effects", dst=relative + "include/effects")
         self.copy("*.h*", src=base + "include/gpu", dst=relative + "include/gpu")
         self.copy("*.h*", src=base + "include/private", dst=relative + "include/private")
 


### PR DESCRIPTION
The headers in the effects include folder are needed for work currently being done on the vector tiles software rasterizer.