### PR TITLE
arch: Use the 3rdparty freetype instead of the system for linux

### DIFF
--- a/skia.lua
+++ b/skia.lua
@@ -470,7 +470,7 @@ end
 
 if (_PLATFORM_LINUX) then
   includedirs {
-    "/usr/include/freetype2",
+    _3RDPARTY_DIR .. "/freetype/include",
   }
 
   files {


### PR DESCRIPTION
Issue-number: https://devtopia.esri.com/runtime/devops/issues/1439
vTest: https://runtime-rtc.esri.com/view/vTest/job/vtest/job/3rdparty-interface/433/

This PR switches skia to use the internal freetype 3rdparty library instead of the system one.