### PR TITLE
windows: Remove the use of a banned API call SystemParametersInfoW

### DIFF
--- a/src/ports/SkFontMgr_win_dw.cpp
+++ b/src/ports/SkFontMgr_win_dw.cpp
@@ -1270,10 +1270,11 @@ SK_API sk_sp<SkFontMgr> SkFontMgr_New_DirectWrite(IDWriteFactory* factory,
     const WCHAR* defaultFamilyName = L"";
     int defaultFamilyNameLen = 1;
 
-    #ifndef SK_WINUWP
+    #ifndef RTC_WINDOWS_FAMILY
     NONCLIENTMETRICSW metrics;
     metrics.cbSize = sizeof(metrics);
 
+    #ifndef SK_WINUWP
     if (nullptr == fallback) {
         if (SystemParametersInfoW(SPI_GETNONCLIENTMETRICS, sizeof(metrics), &metrics, 0)) {
             defaultFamilyName = metrics.lfMessageFont.lfFaceName;
@@ -1281,6 +1282,7 @@ SK_API sk_sp<SkFontMgr> SkFontMgr_New_DirectWrite(IDWriteFactory* factory,
         }
     }
     #endif //SK_WINUWP
+    #endif // RTC_WINDOWS_FAMILY
 
     WCHAR localeNameStorage[LOCALE_NAME_MAX_LENGTH];
     const WCHAR* localeName = L"";


### PR DESCRIPTION
Issue-number: https://devtopia.esri.com/runtime/devops/issues/1683

To use win32 on UWP, the banned System call cannot be used in order to pass
verification. Have Desktop follow the UWP code path

@itrombley this PR reinstates some original skia code we modified at https://github.com/Esri/skia/pull/11/commits/c8ee9c242376021557f9369fa1c8a2c0c4fe49e5 but
removes the code path for all our Windows platforms. It appears to be a corner-case that I'm hoping we can safely remove.