### PR TITLE
android: Add a missing needed header when using anroid API 26

### DIFF
--- a/include/core/SkImage.h
+++ b/include/core/SkImage.h
@@ -23,6 +23,7 @@
 #include <functional>  // std::function
 
 #if defined(SK_BUILD_FOR_ANDROID) && __ANDROID_API__ >= 26
+#include "include/gpu/GrTypes.h"
 #include <android/hardware_buffer.h>
 #endif
 

--- a/include/core/SkSurface.h
+++ b/include/core/SkSurface.h
@@ -18,6 +18,7 @@
 #endif
 
 #if defined(SK_BUILD_FOR_ANDROID) && __ANDROID_API__ >= 26
+#include "include/gpu/GrTypes.h"
 #include <android/hardware_buffer.h>
 #endif
 


### PR DESCRIPTION
Issue-number: https://devtopia.esri.com/runtime/devops/issues/2486
vTest: https://runtime-rtc.esri.com/view/vTest/job/vtest/job/3rdparty-interface/616/downstreambuildview/

Cherry-picked the needed fix from https://github.com/Esri/skia/commit/40d29bfd33c33e97bb3c412c901fb7ecbede9594