### PR TITLE
config: NOLINT forward declaration warning

### DIFF
--- a/src/core/SkVM_fwd.h
+++ b/src/core/SkVM_fwd.h
@@ -11,7 +11,7 @@
 namespace skvm {
     class Assembler;
     class Builder;
-    class Program;
+    class Program; // NOLINT(bugprone-forward-declaration-namespace)
     struct Ptr;
     struct I32;
     struct F32;


### PR DESCRIPTION
**Issue:** https://devtopia.esri.com/runtime/apollo/issues/873

Fix a clang-tidy-pending warning.  Since we only deploy a subset of `skia` to our devs, the `Program` type isn't used without our codebase.

Note we have other modifications to this repository in the `runtimecore` branch, so I don't think this is diverging our production branch from the upstream any more than it already has been.

* [3rdparty vTest](https://runtime-rtc.esri.com/view/vTest/job/vtest/job/3rdparty-interface/1084/downstreambuildview/)
* [RTC vTest](https://runtime-rtc.esri.com/view/vTest/job/vtest/job/runtimecore-interface/25714/downstreambuildview/)