### PR TITLE
Globally disable `HSW` and `SKX` for `SKCMS`

### DIFF
--- a/skia.lua
+++ b/skia.lua
@@ -14,6 +14,8 @@ defines {
   "SK_ENCODE_JPEG",
   "SK_ENCODE_PNG",
   "SK_HAS_WUFFS_LIBRARY",
+  "SKCMS_DISABLE_HSW",
+  "SKCMS_DISABLE_SKX",
 }
 
 includedirs {
@@ -28,8 +30,6 @@ includedirs {
 files {
   "modules/skcms/skcms.cc",
   "modules/skcms/src/skcms_TransformBaseline.cc",
-  "modules/skcms/src/skcms_TransformHsw.cc",
-  "modules/skcms/src/skcms_TransformSkx.cc",
   "src/base/SkArenaAlloc.cpp",
   "src/base/SkBezierCurves.cpp",
   "src/base/SkBlockAllocator.cpp",
@@ -621,11 +621,6 @@ if (_PLATFORM_IOS) then
 end
 
 if (_PLATFORM_LINUX) then
-  defines {
-    "SKCMS_DISABLE_HSW",
-    "SKCMS_DISABLE_SKX",
-  }
-
   includedirs {
     _3RDPARTY_DIR .. "/freetype/include",
   }


### PR DESCRIPTION
- Define `SKCMS_DISABLE_HSW` and `SKCMS_DISABLE_SKX` for all platforms
- Remove `modules/skcms/src/skcms_TransformHsw.cc` and `modules/skcms/src/skcms_TransformSkx.cc` source files

**Runtime 3rdparty build**
https://runtime-rtc.esri.com/view/vTest/job/vtest/job/3rdparty-interface/1876/downstreambuildview/
