### PR TITLE
Disable SIMD for raster processor

### DIFF
--- a/skia.lua
+++ b/skia.lua
@@ -577,9 +577,17 @@ if (_PLATFORM_ANDROID) then
 
   configuration { "*x64*" }
 
+  defines {
+    "SKRP_CPU_SCALAR",
+  }
+
   files { opts_sse }
 
   configuration { "*x86*" }
+
+  defines {
+    "SKRP_CPU_SCALAR",
+  }
 
   files { opts_sse }
 end
@@ -599,6 +607,10 @@ if (_PLATFORM_COCOA) then
 
   configuration { "*x64*" }
 
+  defines {
+    "SKRP_CPU_SCALAR",
+  }
+
   files { opts_sse }
 end
 
@@ -617,12 +629,20 @@ if (_PLATFORM_IOS) then
 
   configuration { "*x64*" }
 
+  defines {
+    "SKRP_CPU_SCALAR",
+  }
+
   files { opts_sse }
 end
 
 if (_PLATFORM_LINUX) then
   includedirs {
     _3RDPARTY_DIR .. "/freetype/include",
+  }
+
+  defines {
+    "SKRP_CPU_SCALAR",
   }
 
   files {
@@ -646,6 +666,10 @@ if (_PLATFORM_MACOS) then
 
   configuration { "x64" }
 
+  defines {
+    "SKRP_CPU_SCALAR",
+  }
+
   files { opts_sse }
 end
 
@@ -657,6 +681,10 @@ if (_PLATFORM_WINDOWS) then
   includedirs {
     "include/utils/win",
     "src/utils/win",
+  }
+
+  defines {
+    "SKRP_CPU_SCALAR",
   }
 
   files {


### PR DESCRIPTION
**Issue**
https://devtopia.esri.com/runtime/apollo/issues/1604

Disable SIMD for raster processor on Intel CPUs: if we compile to a specific level of SIMD and it's run on a processor that doesn't support that level of SIMD then it will crash with an illegal instruction error. It's safe to leave this enabled for ARM as there are only two versions of NEON instructions - one for 32 bit and one for 64 bit.

**Library Build**
https://runtime-rtc.esri.com/view/vTest/job/vtest/job/3rdparty-interface/1959/downstreambuildview/

**Runtimecore Build and Test**
https://runtime-rtc.esri.com/view/vTest/job/vtest/job/runtimecore-interface/46275/downstreambuildview/