### PR TITLE
Use `SK_CPU_SSE_LEVEL_SSSE3` for Intel CPUs

### DIFF
--- a/skia.lua
+++ b/skia.lua
@@ -18,6 +18,10 @@ defines {
   "SKCMS_DISABLE_SKX",
 }
 
+local defines_sse = {
+  "SK_CPU_SSE_LEVEL=SK_CPU_SSE_LEVEL_SSSE3",
+}
+
 includedirs {
   ".",
   "modules/skcms",
@@ -577,17 +581,13 @@ if (_PLATFORM_ANDROID) then
 
   configuration { "*x64*" }
 
-  defines {
-    "SK_CPU_SSE_LEVEL=SK_CPU_SSE_LEVEL_SSSE3",
-  }
+  defines { defines_sse }
 
   files { opts_sse }
 
   configuration { "*x86*" }
 
-  defines {
-    "SK_CPU_SSE_LEVEL=SK_CPU_SSE_LEVEL_SSSE3",
-  }
+  defines { defines_sse }
 
   files { opts_sse }
 end
@@ -607,9 +607,7 @@ if (_PLATFORM_COCOA) then
 
   configuration { "*x64*" }
 
-  defines {
-    "SK_CPU_SSE_LEVEL=SK_CPU_SSE_LEVEL_SSSE3",
-  }
+  defines { defines_sse }
 
   files { opts_sse }
 end
@@ -629,9 +627,7 @@ if (_PLATFORM_IOS) then
 
   configuration { "*x64*" }
 
-  defines {
-    "SK_CPU_SSE_LEVEL=SK_CPU_SSE_LEVEL_SSSE3",
-  }
+  defines { defines_sse }
 
   files { opts_sse }
 end
@@ -641,9 +637,7 @@ if (_PLATFORM_LINUX) then
     _3RDPARTY_DIR .. "/freetype/include",
   }
 
-  defines {
-    "SK_CPU_SSE_LEVEL=SK_CPU_SSE_LEVEL_SSSE3",
-  }
+  defines { defines_sse }
 
   files {
     common_linux,
@@ -666,9 +660,7 @@ if (_PLATFORM_MACOS) then
 
   configuration { "x64" }
 
-  defines {
-    "SK_CPU_SSE_LEVEL=SK_CPU_SSE_LEVEL_SSSE3",
-  }
+  defines { defines_sse }
 
   files { opts_sse }
 end
@@ -683,9 +675,7 @@ if (_PLATFORM_WINDOWS) then
     "src/utils/win",
   }
 
-  defines {
-    "SK_CPU_SSE_LEVEL=SK_CPU_SSE_LEVEL_SSSE3",
-  }
+  defines { defines_sse }
 
   files {
     common_win,

--- a/skia.lua
+++ b/skia.lua
@@ -540,7 +540,7 @@ local common_android = {
 
 -- add common MacOS and iOS
 
-local common_cocoa = {
+local common_apple = {
   common_unix,
   "src/ports/SkFontMgr_mac_ct.cpp",
   "src/ports/SkScalerContext_mac_ct.cpp",
@@ -592,33 +592,13 @@ if (_PLATFORM_ANDROID) then
   files { opts_sse }
 end
 
-if (_PLATFORM_COCOA) then
-  includedirs {
-    "include/utils/mac",
-  }
-
-  files {
-    common_cocoa,
-  }
-
-  configuration { "*arm64*" }
-
-  files { opts_arm64 }
-
-  configuration { "*x64*" }
-
-  defines { defines_sse }
-
-  files { opts_sse }
-end
-
 if (_PLATFORM_IOS) then
   includedirs {
     "include/utils/mac",
   }
 
   files {
-    common_cocoa,
+    common_apple,
   }
 
   configuration { "*arm64*" }
@@ -651,7 +631,7 @@ if (_PLATFORM_MACOS) then
   }
 
   files {
-    common_cocoa,
+    common_apple,
   }
 
   configuration { "ARM64" }

--- a/skia.lua
+++ b/skia.lua
@@ -577,9 +577,17 @@ if (_PLATFORM_ANDROID) then
 
   configuration { "*x64*" }
 
+  defines {
+    "SK_CPU_SSE_LEVEL=SK_CPU_SSE_LEVEL_SSSE3",
+  }
+
   files { opts_sse }
 
   configuration { "*x86*" }
+
+  defines {
+    "SK_CPU_SSE_LEVEL=SK_CPU_SSE_LEVEL_SSSE3",
+  }
 
   files { opts_sse }
 end
@@ -599,6 +607,10 @@ if (_PLATFORM_COCOA) then
 
   configuration { "*x64*" }
 
+  defines {
+    "SK_CPU_SSE_LEVEL=SK_CPU_SSE_LEVEL_SSSE3",
+  }
+
   files { opts_sse }
 end
 
@@ -617,12 +629,20 @@ if (_PLATFORM_IOS) then
 
   configuration { "*x64*" }
 
+  defines {
+    "SK_CPU_SSE_LEVEL=SK_CPU_SSE_LEVEL_SSSE3",
+  }
+
   files { opts_sse }
 end
 
 if (_PLATFORM_LINUX) then
   includedirs {
     _3RDPARTY_DIR .. "/freetype/include",
+  }
+
+  defines {
+    "SK_CPU_SSE_LEVEL=SK_CPU_SSE_LEVEL_SSSE3",
   }
 
   files {
@@ -646,6 +666,10 @@ if (_PLATFORM_MACOS) then
 
   configuration { "x64" }
 
+  defines {
+    "SK_CPU_SSE_LEVEL=SK_CPU_SSE_LEVEL_SSSE3",
+  }
+
   files { opts_sse }
 end
 
@@ -657,6 +681,10 @@ if (_PLATFORM_WINDOWS) then
   includedirs {
     "include/utils/win",
     "src/utils/win",
+  }
+
+  defines {
+    "SK_CPU_SSE_LEVEL=SK_CPU_SSE_LEVEL_SSSE3",
   }
 
   files {


### PR DESCRIPTION
Use the esri maximum supported SIMD level of SSSE3 for Intel CPUs. This won't enable SIMD on Windows as there are compile issues with VC++ and SIMD is explicitly disabled in the code.

**Library Build**
~https://runtime-rtc.esri.com/view/vTest/job/vtest/job/3rdparty-interface/1960/downstreambuildview/~
https://runtime-rtc.esri.com/view/vTest/job/vtest/job/3rdparty-interface/1961/downstreambuildview/

**Runtimecore Build and Test**
~https://runtime-rtc.esri.com/view/vTest/job/vtest/job/runtimecore-interface/46297/downstreambuildview/~
https://runtime-rtc.esri.com/view/vTest/job/vtest/job/runtimecore-interface/46301/downstreambuildview/
